### PR TITLE
Importação de dados e visualização de gráficos dos dados da planilha do Resocie referente as contas do YouTube

### DIFF
--- a/config/resocie.json
+++ b/config/resocie.json
@@ -18,12 +18,12 @@
 			"likesType": "likes",
 			"followersType": "followers"
 		}],
-		"facebookRange": [{
+		"facebookRange": {
 			"linkCol": 3,
 			"likesCol": 4,
 			"followersCol": 5,
 			"dateCol": 6
-		}],
+		},
 		"twitterRange": {
 			"nameRow": 0,
 			"profileRow": 7,
@@ -35,14 +35,19 @@
 			"campaignsRow": 13,
 			"dateRow": 14
 		},
-		"range": [{
-			"nameCol": 0,
+		"youtubeRange": {
+			"dateRow": 14,
+			"channelRow": 19,
+			"subscribsRow": 20,
+			"videosRow": 21,
+			"viewsRow": 22
+		},
+		"range": {
+			"nameRow": 0,
 			"twitterMin": 7,
 			"twitterMax": 14,
 			"instagramMin": 15,
-			"instagramMax": 18,
-			"youtubeMin": 19,
-			"youtubeMax": 22
-		}]
+			"instagramMax": 18
+		}
 	}]
 }

--- a/config/resocie.json
+++ b/config/resocie.json
@@ -50,7 +50,7 @@
 			"postsRow": 18,
 			"dateRow": 14
 		},
-		"range": [{
+		"range": {
 			"nameRow": 0,
 			"twitterMin": 7,
 			"twitterMax": 14,

--- a/server/controllers/facebook.controller.js
+++ b/server/controllers/facebook.controller.js
@@ -367,7 +367,7 @@ const importAccounts = async (req, res) => {
 	const actors = {};
 	const categories = req.sheet.categories;
 	const facebookRange = req.sheet.facebookRange;
-	const nameCol = req.sheet.range[0].nameCol;
+	const nameCol = req.sheet.range.nameRow;
 	const linkCol = facebookRange[0].linkCol;
 	const likesCol = facebookRange[0].likesCol;
 	const followersCol = facebookRange[0].followersCol;

--- a/server/controllers/facebook.controller.js
+++ b/server/controllers/facebook.controller.js
@@ -379,10 +379,10 @@ const importAccounts = async (req, res) => {
 	const categories = req.sheet.categories;
 	const facebookRange = req.sheet.facebookRange;
 	const nameCol = req.sheet.range.nameRow;
-	const linkCol = facebookRange[0].linkCol;
-	const likesCol = facebookRange[0].likesCol;
-	const followersCol = facebookRange[0].followersCol;
-	const dateCol = facebookRange[0].dateCol;
+	const linkCol = facebookRange.linkCol;
+	const likesCol = facebookRange.likesCol;
+	const followersCol = facebookRange.followersCol;
+	const dateCol = facebookRange.dateCol;
 	let cCategory = 0;
 	let lastDate;
 

--- a/server/controllers/youtube.controller.js
+++ b/server/controllers/youtube.controller.js
@@ -1,0 +1,293 @@
+const httpStatus = require("http-status");
+const youtubeAccount = require("../models/youtube.model");
+const ChartNode = require("chartjs-node");
+const logger = require("../../config/logger");
+
+// Carrega todos os usuários do banco de dados
+const listAccounts = async (req, res) => {
+	try {
+		const accounts = await youtubeAccount.find({}, "name -_id");
+		res.status(httpStatus.OK).json({
+			error: false,
+			accounts: accounts,
+		});
+	} catch (error) {
+		const msg = "Erro ao carregar os usuários do YouTube do banco de dados";
+		logger.error(msg);
+
+		res.status(httpStatus.INTERNAL_SERVER_ERROR).json({
+			error: true,
+			description: msg,
+		});
+	}
+};
+
+const importData = async (req, res) => {
+	const actors = {};
+	const tabs = req.collectives;
+	const length = tabs.length;
+	const categories = req.sheet.categories;
+	const youtubeRange = req.sheet.youtubeRange;
+	const nameRow = req.sheet.range.nameRow;
+	const dateRow = youtubeRange.dateRow;
+	const channelRow = youtubeRange.channelRow;
+	const subscribRow = youtubeRange.subscribRow;
+	const videosRow = youtubeRange.videosRow;
+	const viewsRow = youtubeRange.viewsRow;
+	let cCategory;
+	let lastDate;
+
+	for (let ind = 0; ind < length; ind += 1) {
+		const cTab = tabs[ind];
+		const rowsCount = cTab.length;
+		cCategory = 0;
+
+		for (let j = 0; j < rowsCount; j += 1) {
+			const cRow = cTab[j];
+
+			if (j < 1 || !(cRow[nameRow])) {
+				continue; // eslint-disable-line no-continue
+			}
+
+			if (cRow[nameRow] === categories[cCategory + 1]) {
+				cCategory += 1;
+				continue; // eslint-disable-line no-continue
+			}
+			// Se estiver em uma row com nome vazio ou a primeira
+			// continue
+
+			let channel;
+			if (isCellValid(cRow[channelRow])) {
+				channel = cRow[channelRow];
+			} else {
+				channel = null;
+			}
+			// Cria um novo schema para caso nao exista no bd
+			if (actors[cRow[nameRow]] === undefined) {
+				const newAccount = youtubeAccount({
+					name: cRow[nameRow],
+					category: categories[cCategory],
+					channelUrl: channel,
+				});
+				actors[cRow[nameRow]] = newAccount;
+			}	
+
+			if (channel) {
+				console.log(channel);
+				for (let k = subscribRow; k <= viewsRow; k += 1) {
+					console.log("valor k");
+					console.log(k);
+					console.log(cRow[k]);
+
+					if (!isCellValid(cRow[k])) {
+						console.log("invalido");
+						cRow[k] = null;
+					} else {
+						// restringir esta parte
+						cRow[k] = parseInt(cRow[k].replace(/\.|,/g, ""), 10);
+						console.log(cRow);
+						if (Number.isNaN(cRow[k])) cRow[k] = null;
+					}
+				}
+
+				// Parses the date of the sample and use the last one if something wrong happens
+				let newDate = cRow[dateRow];
+				if (newDate) newDate = newDate.split("/");
+				if (!(newDate) || newDate.length !== 3) newDate = lastDate;
+				lastDate = newDate;
+
+				// Defines sample and adds it to the actor document
+				const newHistory = {
+					subscribers: cRow[subscribRow],
+					videos: cRow[videosRow],
+					views: cRow[viewsRow],
+					date: new Date(`${newDate[1]}/${newDate[0]}/${newDate[2]}`),
+				};
+				actors[cRow[nameRow]].history.push(newHistory);
+			}
+		}
+	}
+
+	const savePromises = [];
+	Object.entries(actors).forEach(([cActor]) => {
+		savePromises.push(actors[cActor].save());
+	});
+	await Promise.all(savePromises);
+	return res.redirect("/youtube");
+};
+
+// Carrega uma conta de usuário específico
+const loadAccount = async (req, res, next, name) => {
+	try {
+		const account = await youtubeAccount.findOne({ name }, "-_id -_v");
+		req.account = account;
+		return next();
+	} catch (error) {
+		const msg = `Erro ao carregar o usuário ${name} no banco de dados`;
+		logger.error(msg);
+
+		return res.status(httpStatus.INTERNAL_SERVER_ERROR).json({
+			error: true,
+			description: msg,
+		});
+	}
+};
+
+const getUser = async (req, res) => {
+	try {
+		const account = req.account;
+
+		res.status(httpStatus.OK).json({
+			error: false,
+			account: account,
+		});
+	} catch (error) {
+		const msg = "Erro interno do servidor enquanto buscava a conta";
+		logger.error(msg);
+
+		res.status(httpStatus.INTERNAL_SERVER_ERROR).json({
+			error: true,
+			description: msg,
+		});
+	}
+};
+
+const setHistoryKey = async (req, res, next) => {
+	const historyKey = req.params.query;
+
+	// Título do gráfico gerado
+	let mainLabel;
+
+	// Analisa o caminho da rota que chegou nesta função para
+	// ter um título com o parâmetro correto.
+	switch (historyKey) {
+	case "subscribers":
+		mainLabel = "Evolução do número de curtidas";
+		break;
+	case "videos":
+		mainLabel = "Evolução do número de seguidores";
+		break;
+	case "views":
+		mainLabel = "Evolução do número de usuários que segue";
+		break;
+	default:
+		const msg = `Não existe a caracteristica ${channelKey} para o YouTube`;
+		logger.error(msg);
+
+		return res.status(httpStatus.NOT_FOUND).json({
+			error: true,
+			description: msg,
+		});
+	}
+
+	req.chart = {
+		historyKey: historyKey,
+		mainLabel: mainLabel,
+	};
+	return next();
+};
+
+// Responde com uma imagem (gráfico)
+const getDataset = async (req, res, next) => {
+	// Carrega as samples da conta do usuário
+	const history = req.account.history;
+	const historyKey = req.chart.historyKey;
+
+	const data = [];
+	// const labels = [];
+
+	// Itera sobre todas as samples e adiciona aquelas que tem o dado procurado
+	// na array de dados `data`
+	const length = history.length;
+	for (let ind = 0; ind < length; ind += 1) {
+		const value = history[ind][historyKey];
+
+		if (value !== undefined && value !== null) {
+			const date = new Date(history[ind].date);
+			data.push({
+				x: date,
+				y: value,
+			});
+			// labels.push(date);
+		}
+	}
+
+	const dataset = [{
+		data: data,
+		backgroundColor: "#ff0000",
+		borderColor: "#ffffff",
+		fill: false,
+		label: `${req.account.name} (${req.account.chanelUrl})`,
+	}];
+
+	req.chart.datasets = dataset;
+	next();
+};
+
+// Desenha um gráfico de linha que usa o tempo como eixo X
+const drawLineChart = async (req, res) => {
+	const mainLabel = req.chart.mainLabel;
+	const datasets = req.chart.datasets;
+	const historyKey = req.chart.historyKey;
+	const chartNode = new ChartNode(600, 600);
+	const config = {
+		type: "line",
+		data: {
+			datasets: datasets,
+		},
+		options: {
+			title: {
+				display: true,
+				text: mainLabel,
+			},
+			scales: {
+				xAxes: [{
+					type: "time",
+					time: {
+						tooltipFormat: "ll HH:mm",
+					},
+					ticks: {
+						major: {
+							fontStyle: "bold",
+						},
+					},
+					scaleLabel: {
+						display: true,
+						labelString: "Data",
+					},
+				}],
+				yAxes: [{
+					scaleLabel: {
+						display: true,
+						labelString: `Nº de ${historyKey}`,
+					},
+				}],
+			},
+		},
+	};
+
+	await chartNode.drawChart(config);
+	const buffer = await chartNode.getImageBuffer("image/png");
+	res.writeHead(httpStatus.OK, { "Content-Type": "image/png" });
+	res.write(buffer);
+	res.end();
+};
+
+const isCellValid = (value) => {
+	if (!(value) || value === "-" || value === "s" || value === "s/" || value === "S" || value ==="S/") {
+		return false;
+	}
+
+	return true;
+};
+
+module.exports = {
+	listAccounts,
+	loadAccount,
+	getUser,
+	setHistoryKey,
+	getDataset,
+	drawLineChart,
+	importData,
+
+};

--- a/server/controllers/youtube.controller.js
+++ b/server/controllers/youtube.controller.js
@@ -11,7 +11,7 @@ const logger = require("../../config/logger");
  */
 const listAccounts = async (req, res) => {
 	try {
-		const accounts = await youtubeAccount.find({}, "name -_id");
+		const accounts = await youtubeAccount.find({}, "name channelUrl -_id");
 		res.status(httpStatus.OK).json({
 			error: false,
 			accounts: accounts,

--- a/server/models/youtube.model.js
+++ b/server/models/youtube.model.js
@@ -1,0 +1,39 @@
+const mongoose = require("mongoose");
+
+const youtubeChannel = {
+	subscribers: {
+		type: Number,
+	},
+	videos: {
+		type: Number,
+	},
+	views: {
+		type: Number,
+	},
+	date: {
+		type: Date,
+		required: true,
+		default: Date.now,
+	},
+};
+
+const youtubeAccountSchema = new mongoose.Schema({
+	name: {
+		type: String,
+		required: true,
+	},
+	category: {
+		type: String,
+		default: null,
+	},
+	channelUrl: {
+		type: String,
+		default: null,
+	},
+	history: {
+		type: [youtubeChannel],
+		default: [],
+	},
+});
+
+module.exports = mongoose.model("youtubeAccount", youtubeAccountSchema, "youtubeAccount");

--- a/server/routes/index.route.js
+++ b/server/routes/index.route.js
@@ -2,6 +2,7 @@ const express = require("express");
 const spreadsheetsRoute = require("./spreadsheets.route");
 const twitterRoute = require("./twitter.route");
 const facebookRoute = require("./facebook.route");
+const youtubeRoute = require("./youtube.route");
 
 const router = express.Router();
 
@@ -13,5 +14,8 @@ router.use("/facebook", facebookRoute);
 
 // mount twitter routes at /twitter
 router.use("/twitter", twitterRoute);
+
+// mount youtube routes at /youtube
+router.use("/youtube", youtubeRoute);
 
 module.exports = router;

--- a/server/routes/youtube.route.js
+++ b/server/routes/youtube.route.js
@@ -8,12 +8,14 @@ const router = express.Router(); // eslint-disable-line new-cap
 router.route("/")
 	.get(youtubeCtrl.listAccounts);
 
-// Importa os dados da tabela para o banco de dados
+// Importa os dados da tabela para o banco de dados -> youtube/import
 router.route("/import")
-	.get(spreadsheetsCtrl.authenticate, 
-		spreadsheetsCtrl.setResocieSheet, 
-		spreadsheetsCtrl.listCollectives, 
-		youtubeCtrl.importData);
+	.get(
+		spreadsheetsCtrl.authenticate,
+		spreadsheetsCtrl.setResocieSheet,
+		spreadsheetsCtrl.listCollectives,
+		youtubeCtrl.importData,
+	);
 
 // Lista os dados de um usuario especifico
 router.route("/:name")
@@ -23,7 +25,6 @@ router.route("/:name")
 router.route("/:name/:query")
 	.get(youtubeCtrl.getDataset, youtubeCtrl.drawLineChart);
 
-// Lista um usuario do banco de dados
 router.param("name", youtubeCtrl.loadAccount);
 
 router.param("query", youtubeCtrl.setHistoryKey);

--- a/server/routes/youtube.route.js
+++ b/server/routes/youtube.route.js
@@ -1,0 +1,31 @@
+const express = require("express");
+const youtubeCtrl = require("../controllers/youtube.controller");
+const spreadsheetsCtrl = require("../controllers/spreadsheets.controller");
+
+const router = express.Router(); // eslint-disable-line new-cap
+
+// Lista todas as contas de user youtube
+router.route("/")
+	.get(youtubeCtrl.listAccounts);
+
+// Importa os dados da tabela para o banco de dados
+router.route("/import")
+	.get(spreadsheetsCtrl.authenticate, 
+		spreadsheetsCtrl.setResocieSheet, 
+		spreadsheetsCtrl.listCollectives, 
+		youtubeCtrl.importData);
+
+// Lista os dados de um usuario especifico
+router.route("/:name")
+	.get(youtubeCtrl.getUser);
+
+// Mostra o gráfico de um atributo especifico de um usuario Ex. /youtube/Joao/videos
+router.route("/:name/:query")
+	.get(youtubeCtrl.getDataset, youtubeCtrl.drawLineChart);
+
+// Lista um usuario do banco de dados
+router.param("name", youtubeCtrl.loadAccount);
+
+router.param("query", youtubeCtrl.setHistoryKey);
+
+module.exports = router;

--- a/server/tests/youtube.stub.json
+++ b/server/tests/youtube.stub.json
@@ -1,0 +1,54 @@
+{
+	"accounts": [
+		{
+			"name": "Mariana",
+			"category": "marianacategory",
+			"channelUrl": "youtube.com/user/marianachannel",
+			"history": [
+				{
+					"subscribers": 542,
+					"videos": 420,
+					"views": 24,
+					"date": "1994-12-24T02:00:00.000Z"
+				},
+				{
+					"subscribers": 500,
+					"videos": 840,
+					"views": 84,
+					"date": "1995-01-24T02:00:00.000Z"
+				},				
+				{
+					"subscribers": 532,
+					"videos": 1000,
+					"views": 420,
+					"date": "1995-02-24T02:00:00.000Z"
+				}
+			]
+		},
+		{
+			"name": "Luiza",
+			"category": "luizacategory",
+			"channelUrl": "youtube.com/channel/UCmo_qwwtofscJjjND_Pm-UA",
+			"history": [
+				{
+					"subscribers": 45,
+					"videos": 450,
+					"views": 45,
+					"date": "1994-12-24T02:00:00.000Z"
+				},
+				{
+					"subscribers": 100,
+					"videos": 840,
+					"views": 840,
+					"date": "1995-01-24T02:00:00.000Z"
+				},				
+				{
+					"subscribers": 250,
+					"videos": 1000,
+					"views": 4200,
+					"date": "1995-02-24T02:00:00.000Z"
+				}
+			]
+		}
+	]
+}

--- a/server/tests/youtube.test.js
+++ b/server/tests/youtube.test.js
@@ -1,0 +1,101 @@
+const request = require("supertest");
+const httpStatus = require("http-status");
+const app = require("../../index");
+const youtubeAccount = require("../models/youtube.model");
+const youtubeStub = require("./youtube.stub.json").accounts;
+
+beforeAll(async () => {
+	await youtubeAccount.collection.insert(youtubeStub);
+});
+
+afterAll(async () => {
+	await youtubeAccount.collection.drop();
+});
+
+/**
+ * Test case for the /youtube endpoint.
+ */
+describe("Youtube endpoint", () => {
+	let nameTest;
+
+	// When required, access should be granted
+	it("GET /youtube should return a JSON with all the users in the db", async (done) => {
+		const res = await request(app).get("/youtube").expect(httpStatus.OK);
+
+		expect(res.body).toHaveProperty("error");
+		expect(res.body.error).toBe(false);
+
+		expect(res.body).toHaveProperty("accounts");
+		expect(res.body.accounts).toBeInstanceOf(Object);
+		expect(res.body.accounts.length).toEqual(youtubeStub.length);
+
+		nameTest = res.body.accounts[0].name;
+
+		done();
+	});
+
+	// When requires, access should be granted
+	it("GET /youtube/:name should return all data from a certain user", async (done) => {
+		const res = await request(app).get(`/youtube/${nameTest}`).expect(httpStatus.OK);
+
+		expect(res.body).toHaveProperty("error");
+		expect(res.body.error).toBe(false);
+
+		expect(res.body).toHaveProperty("account");
+		expect(res.body.account).toBeInstanceOf(Object);
+		expect(res.body.account.name).toEqual("Mariana");
+		expect(res.body.account.category).toEqual("marianacategory");
+		expect(res.body.account.channelUrl).toEqual("youtube.com/user/marianachannel");
+		expect(res.body.account.history.length).toEqual(3);
+
+		expect(res.body.account.history[0].subscribers).toEqual(542);
+		expect(res.body.account.history[0].videos).toEqual(420);
+		expect(res.body.account.history[0].views).toEqual(24);
+		expect(res.body.account.history[0].date).toEqual("1994-12-24T02:00:00.000Z");
+
+		expect(res.body.account.history[1].subscribers).toEqual(500);
+		expect(res.body.account.history[1].videos).toEqual(840);
+		expect(res.body.account.history[1].views).toEqual(84);
+		expect(res.body.account.history[1].date).toEqual("1995-01-24T02:00:00.000Z");
+
+		expect(res.body.account.history[2].subscribers).toEqual(532);
+		expect(res.body.account.history[2].videos).toEqual(1000);
+		expect(res.body.account.history[2].views).toEqual(420);
+		expect(res.body.account.history[2].date).toEqual("1995-02-24T02:00:00.000Z");
+
+		done();
+	});
+
+	it("GET /youtube/import shoul import all data from the spreadsheets to localBD", async (done) => {
+		await request(app).get("/youtube/import").expect(httpStatus.FOUND);
+
+		done();
+	});
+
+	// When required, access should be granted
+	it("GET /youtube/:name/subscribers should return an image (the graph)", async (done) => {
+		expect(nameTest).toBeDefined();
+		const res = await request(app).get(`/youtube/${nameTest}/subscribers`).expect(httpStatus.OK);
+		expect(res.header["content-type"]).toEqual("image/png");
+
+		done();
+	});
+
+	// When required, access should be granted
+	it("GET /youtube/:name/videos should return an image (the graph)", async (done) => {
+		expect(nameTest).toBeDefined();
+		const res = await request(app).get(`/youtube/${nameTest}/videos`).expect(httpStatus.OK);
+		expect(res.header["content-type"]).toEqual("image/png");
+
+		done();
+	});
+
+	// When required, access should be granted
+	it("GET /youtube/:name/views should return an image (the graph)", async (done) => {
+		expect(nameTest).toBeDefined();
+		const res = await request(app).get(`/youtube/${nameTest}/views`).expect(httpStatus.OK);
+		expect(res.header["content-type"]).toEqual("image/png");
+
+		done();
+	});
+});


### PR DESCRIPTION
Fim da história #11 
Implementa as rotas que tornam possível visualizar em gráficos de linhas a evolução dos dados presentes na planilha Grupos políticos sobre cada conta do Youtube dos atores políticos e a suite de testes para as rotas.

- /youtube - exibe todas as contas do banco de dados;

- /youtube/import - importa os dados dos atores da planilha do Resocie;

- /youtube/:name - exibe dados de um usuário especifico;

- /youtube/:name/subscribers - exibe um gráfico com a evolução do número de inscritos no canal do usuário;

- /youtube/:name/videos - exibe um gráfico com a evolução do número de vídeos no canal do usuário;

- /youtube/:name/views - exibe um gráfico com a evolução do número de vizualições do canal do usuário;
